### PR TITLE
Considera groupName recebido como parametro na criação do objeto

### DIFF
--- a/src/vtex-ng-filter.coffee
+++ b/src/vtex-ng-filter.coffee
@@ -132,6 +132,7 @@ angular.module('vtexNgFilter', [])
             item.quantity = 0
 
       setGroup: =>
+        return @groupName if @groupName
         if @name in ['creationDate', 'authorizedDate', 'ShippingEstimatedDate']
           @groupName = 'date'
         else if @name in ['SalesChannelName', 'CallCenterOperatorName', 'SellerNames', 'UtmSource', 'affiliateId']


### PR DESCRIPTION
Com isso pode-se criar filtros com nomes não conhecidos pelo módulo de filtro
