### PR TITLE
Fix version of grunt-contrib-coffee

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt": "~0.4.2",
     "grunt-angular-templates": "~0.4.2",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-coffee": "*",
+    "grunt-contrib-coffee": "^1.0.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.5.0",


### PR DESCRIPTION
Previously, npm was installing the latest version of this package.
In the latest version, the Coffeescript code compiled didn't transform
the ES6 class syntax to ES5, eg: it kept `class Filter` in the code.

Uglify doesn't parse ES6 code and it crashed.

This commit changes the major version of the grunt-contrib-coffee package
to 1. This version transform the ES6 class syntax to ES5 and Uglify can do
its job.